### PR TITLE
Add tooltip labels to Leaderboard scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,78 +25,83 @@
         <div class="rank">1</div>
         <div class="name">Dioxus</div>
         <div class="scores">
-          <div class="score">5</div>
-          <div class="score">5</div>
-          <div class="score">2</div>
-          <div class="score">4</div>
-          <div class="score">4</div>
-          <div class="main">20</div>
+          <div class="score" data-toggle="tooltip" title="OS Support">5</div>
+          <div class="score" data-toggle="tooltip" title="Tooling">5</div>
+          <div class="score" data-toggle="tooltip" title="Community Support & Documentation">2</div>
+          <div class="score" data-toggle="tooltip" title="Developer Experience">4</div>
+          <div class="score" data-toggle="tooltip" title="Theming">4</div>
+          <div class="main" data-toggle="tooltip" title="Total">20</div>
         </div>
       </div>
       <div class="leaderboard-item">
         <div class="rank">2</div>
         <div class="name">Slint</div>
         <div class="scores">
-          <div class="score">4</div>
-          <div class="score">3</div>
-          <div class="score">3.5</div>
-          <div class="score">2.5</div>
-          <div class="score">5</div>
-          <div class="main">18</div>
+          <div class="score" data-toggle="tooltip" title="OS Support">4</div>
+          <div class="score" data-toggle="tooltip" title="Tooling">3</div>
+          <div class="score" data-toggle="tooltip" title="Community Support & Documentation">3.5</div>
+          <div class="score" data-toggle="tooltip" title="Developer Experience">2.5</div>
+          <div class="score" data-toggle="tooltip" title="Theming">5</div>
+          <div class="main" data-toggle="tooltip" title="Total">18</div>
         </div>
       </div>
       <div class="leaderboard-item">
         <div class="rank">2</div>
         <div class="name">Leptos</div>
         <div class="scores">
-          <div class="score">3</div>
-          <div class="score">3</div>
-          <div class="score">5</div>
-          <div class="score">3</div>
-          <div class="score">4</div>
-          <div class="main">18</div>
+          <div class="score" data-toggle="tooltip" title="OS Support">3</div>
+          <div class="score" data-toggle="tooltip" title="Tooling">3</div>
+          <div class="score" data-toggle="tooltip" title="Community Support & Documentation">5</div>
+          <div class="score" data-toggle="tooltip" title="Developer Experience">3</div>
+          <div class="score" data-toggle="tooltip" title="Theming">4</div>
+          <div class="main" data-toggle="tooltip" title="Total">18</div>
         </div> 
       </div>
       <div class="leaderboard-item">
         <div class="rank">4</div>
         <div class="name">Iced</div>
         <div class="scores">
-          <div class="score">3</div>
-          <div class="score">5</div>
-          <div class="score">2</div>
-          <div class="score">4</div>
-          <div class="score">3</div>
-          <div class="main">17</div>
+          <div class="score" data-toggle="tooltip" title="OS Support">3</div>
+          <div class="score" data-toggle="tooltip" title="Tooling">5</div>
+          <div class="score" data-toggle="tooltip" title="Community Support & Documentation">2</div>
+          <div class="score" data-toggle="tooltip" title="Developer Experience">4</div>
+          <div class="score" data-toggle="tooltip" title="Theming">3</div>
+          <div class="main" data-toggle="tooltip" title="Total">17</div>
         </div>
       </div>
       <div class="leaderboard-item">
         <div class="rank">5</div>
         <div class="name">Ratatui</div>
         <div class="scores">
-          <div class="score">3</div>
-          <div class="score">2</div>
-          <div class="score">5</div>
-          <div class="score">4</div>
-          <div class="score">3</div>
-          <div class="main">17</div>
+          <div class="score" data-toggle="tooltip" title="OS Support">3</div>
+          <div class="score" data-toggle="tooltip" title="Tooling">2</div>
+          <div class="score" data-toggle="tooltip" title="Community Support & Documentation">5</div>
+          <div class="score" data-toggle="tooltip" title="Developer Experience">4</div>
+          <div class="score" data-toggle="tooltip" title="Theming">3</div>
+          <div class="main" data-toggle="tooltip" title="Total">17</div>
         </div>
       </div>
       <div class="leaderboard-item">
         <div class="rank">6</div>
         <div class="name">Cursive</div>
         <div class="scores">
-          <div class="score">4</div>
-          <div class="score">1</div>
-          <div class="score">3</div>
-          <div class="score">3</div>
-          <div class="score">4</div>
-          <div class="main">15</div>
+          <div class="score" data-toggle="tooltip" title="OS Support">4</div>
+          <div class="score" data-toggle="tooltip" title="Tooling">1</div>
+          <div class="score" data-toggle="tooltip" title="Community Support & Documentation">3</div>
+          <div class="score" data-toggle="tooltip" title="Developer Experience">3</div>
+          <div class="score" data-toggle="tooltip" title="Theming">4</div>
+          <div class="main" data-toggle="tooltip" title="Total">15</div>
         </div>
       </div>
     </section>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js">
     </script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.bundle.min.js">
+    </script>
+    <script>
+        $(function () {
+          $('[data-toggle="tooltip"]').tooltip()
+        })
     </script>
   </body>
 </html>


### PR DESCRIPTION
I added Score labels based on the order presented in the [Dioxus vs Leptos | Rust GUI Wars #2](https://www.youtube.com/watch?v=eWuEs23sIOY) video. Since this simple page used Bootstrap 4.5, I enabled the Bootstrap tooltips as shown in their [documentation](https://getbootstrap.com/docs/4.5/components/tooltips/#overview).

Thanks for the analysis on youtube! I found it helpful when choosing which GUI framework to use in Rust 🦀